### PR TITLE
Initial connection pool implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,13 @@
 [package]
-name = "rust-cueball"
+name = "cueball"
 version = "0.1.0"
 authors = ["Kelly McLaughlin <kelly.mclaughlin@joyent.com>"]
 edition = "2018"
 
 [dependencies]
-
-scheduled-thread-pool = "0.2.0"
+base64 = "0.10.1"
+sha1 = "0.6.0"
 slog = "2.4.1"
+
+[dev-dependencies]
+slog-term = "2.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies]
 base64 = "0.10.1"
+derive_more = "0.14.0"
 sha1 = "0.6.0"
 slog = "2.4.1"
 

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,0 +1,181 @@
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::sync::{Arc, Barrier, Mutex};
+use std::sync::mpsc::Sender;
+use std::thread;
+
+use slog::{Drain, Logger, info, o};
+
+use cueball::backend;
+use cueball::backend::{Backend, BackendAddress, BackendPort};
+use cueball::connection::Connection;
+use cueball::connection_pool::ConnectionPool;
+use cueball::connection_pool::types::ConnectionPoolOptions;
+use cueball::error::Error;
+use cueball::resolver::{BackendAddedMsg, BackendMsg, Resolver};
+
+
+#[derive(Debug)]
+pub struct DummyConnection {
+    addr: SocketAddr,
+    connected: bool
+}
+
+impl Connection for DummyConnection {
+    fn new(b: &Backend) -> Self {
+        let addr = SocketAddr::from((b.address, b.port));
+
+        DummyConnection {
+            addr: addr,
+            connected: false
+        }
+    }
+
+    fn connect(&mut self) -> Result<(), Error> {
+        self.connected = true;
+        Ok(())
+    }
+
+    fn close(&mut self) -> Result<(), Error> {
+        self.connected = false;
+        Ok(())
+    }
+
+    fn set_unwanted(&self) {
+        ()
+    }
+}
+
+pub struct FakeResolver {
+    backends: Vec<(BackendAddress, BackendPort)>,
+    pool_tx: Option<Sender<BackendMsg>>,
+    error: Option<Error>,
+    started: bool
+}
+
+impl FakeResolver {
+    pub fn new(backends: Vec<(BackendAddress, BackendPort)>) -> Self {
+        FakeResolver {
+            backends: backends,
+            pool_tx: None,
+            error: None,
+            started: false
+        }
+    }
+}
+
+impl Resolver for FakeResolver {
+    fn start(&mut self, s: Sender<BackendMsg>) {
+        if !self.started {
+            self.backends.iter().for_each(|b| {
+                let backend = Backend::new(&b.0, &b.1);
+                let backend_key = backend::srv_key(&backend);
+                let backend_msg =
+                    BackendMsg::AddedMsg(
+                        BackendAddedMsg {
+                            key: backend_key,
+                            backend: backend
+                        });
+                s.send(backend_msg).unwrap();
+            });
+            self.pool_tx = Some(s);
+            self.started = true;
+        }
+    }
+
+    fn stop(&mut self) {
+        self.started = false;
+        ()
+    }
+
+    fn get_last_error(&self) -> Option<String> {
+        if let Some(err) = &self.error {
+                let err_str = format!("{}", err);
+                Some(err_str)
+        } else {
+            None
+        }
+    }
+}
+
+fn main() {
+    let plain = slog_term::PlainSyncDecorator::new(std::io::stdout());
+    let log = Logger::root(
+        Mutex::new(
+            slog_term::FullFormat::new(plain).build()
+        ).fuse(),
+        o!("build-id" => "0.1.0")
+    );
+
+    info!(log, "running basic cueball example");
+
+    // Start a pool and start some threads to use connections
+    let be1 = (IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 55555);
+    let be2 = (IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 55556);
+    let be3 = (IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 55557);
+
+    let resolver = FakeResolver::new(vec![be1, be2, be3]);
+
+    let pool_opts = ConnectionPoolOptions::<FakeResolver> {
+        domain: String::from("abc.com"),
+        spares: 3,
+        maximum: 5,
+        service: None,
+        claim_timeout: Some(100),
+        resolver: resolver,
+        log: log.clone()
+    };
+
+    let pool = ConnectionPool::<DummyConnection, FakeResolver>::new(pool_opts);
+
+    let barrier1 = Arc::new(Barrier::new(4));
+    let barrier2 = Arc::new(Barrier::new(4));
+
+    let barrier1_clone1 = barrier1.clone();
+    let barrier2_clone1 = barrier2.clone();
+    let pool_clone1 = pool.clone();
+    let thread1 = thread::spawn(move || {
+        let conn_result = pool_clone1.claim();
+        assert!(conn_result.is_ok());
+        barrier1_clone1.wait();
+        barrier2_clone1.wait();
+    });
+
+    let barrier1_clone2 = barrier1.clone();
+    let barrier2_clone2 = barrier2.clone();
+    let pool_clone2 = pool.clone();
+    let thread2 = thread::spawn(move || {
+        let conn_result = pool_clone2.claim();
+        assert!(conn_result.is_ok());
+        barrier1_clone2.wait();
+        barrier2_clone2.wait();
+    });
+
+    let barrier1_clone3 = barrier1.clone();
+    let barrier2_clone3 = barrier2.clone();
+    let pool_clone3 = pool.clone();
+    let thread3 = thread::spawn(move || {
+        let conn_result = pool_clone3.claim();
+        assert!(conn_result.is_ok());
+        barrier1_clone3.wait();
+        barrier2_clone3.wait();
+    });
+
+    barrier1.wait();
+
+    let m_claim1 = pool.try_claim();
+    assert!(m_claim1.is_none());
+
+    // This will timeout after 100 ms based on the claim_timeout specfied in the
+    // pool options
+    let m_claim2 = pool.claim();
+    assert!(m_claim2.is_err());
+
+    barrier2.wait();
+
+    let _  = thread1.join();
+    let _  = thread2.join();
+    let _  = thread3.join();
+
+    let m_claim3 = pool.try_claim();
+    assert!(m_claim3.is_some());
+}

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 Joyent, Inc.
+ */
+
+use std::net::IpAddr;
+
+use base64;
+use sha1::Sha1;
+
+// TODO: At least BackendKey needs to be a newtype
+pub type BackendKey = String;
+pub type BackendPort = u16;
+pub type BackendName = String;
+pub type BackendAddress = IpAddr;
+
+pub struct Backend {
+    pub name: BackendName,
+    pub address: BackendAddress,
+    pub port: BackendPort
+}
+
+impl Backend {
+    pub fn new(address: &BackendAddress, port: &BackendPort) -> Self {
+        Backend {
+            name: backend_name(address, port),
+            address: address.clone(),
+            port: port.clone()
+        }
+    }
+}
+
+fn backend_name(address: &BackendAddress, port: &BackendPort) -> BackendName {
+    let address_str = format!("{}", address);
+    [address_str, String::from(":"), port.to_string()].concat()
+}
+
+pub fn srv_key(backend: &Backend) -> BackendKey {
+    let mut sha1 = Sha1::new();
+    sha1.update(backend.name.as_bytes());
+    sha1.update(b"||");
+    sha1.update(backend.port.to_string().as_bytes());
+    sha1.update(b"||");
+    sha1.update(backend.address.to_string().as_bytes());
+
+    base64::encode(&sha1.digest().bytes())
+}

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -13,6 +13,7 @@ pub type BackendPort = u16;
 pub type BackendName = String;
 pub type BackendAddress = IpAddr;
 
+#[derive(Clone, Debug)]
 pub struct Backend {
     pub name: BackendName,
     pub address: BackendAddress,

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -2,12 +2,12 @@
  * Copyright 2019 Joyent, Inc.
  */
 
+use crate::backend::Backend;
 use crate::error::Error;
 
-pub trait Connection: Send + Sync {
-    type Connection: Send;
-
-    fn connect(&self) -> Result<Self::Connection, Error>;
-    fn close(&self) -> Result<(), Error>;
+pub trait Connection: Send + Sync + Sized + 'static {
+    fn new(b: &Backend) -> Self;
+    fn connect(&mut self) -> Result<(), Error>;
+    fn close(&mut self) -> Result<(), Error>;
     fn set_unwanted(&self) -> ();
 }

--- a/src/connection_pool.rs
+++ b/src/connection_pool.rs
@@ -2,38 +2,66 @@
  * Copyright 2019 Joyent, Inc.
  */
 
-use std::vec::Vec;
+pub mod types;
+
+use std::marker::PhantomData;
+use std::ops::DerefMut;
+use std::sync::{Arc, Barrier};
+use std::sync::mpsc::{channel, Receiver};
+use std::thread;
+
+use slog::{Logger, warn, error};
 
 use crate::connection::Connection;
+use crate::connection_pool::types::{ConnectionData,
+                                    ConnectionKeyPair,
+                                    ConnectionPoolOptions,
+                                    ConnectionPoolStats,
+                                    ProtectedData};
 use crate::error::Error;
-use crate::resolver::Resolver;
+use crate::resolver::{BackendAddedMsg,
+                      BackendMsg,
+                      BackendRemovedMsg,
+                      Resolver};
 
+// General TODOs
+// * Incorporate pending_connections
+// * More logging
+// * Consider removing idle_connections stat and use connections queue size
+//   instead for less overhead and reduced chance of accounting error.
+// * Connection rebalancing and decoherence
 
-pub struct ConnectionPoolStats {
-    total_connections: u32,
-    idle_connections: u32,
-    pending_connections: u32
-}
-
-pub struct ConnectionPoolOptions<R> {
-    domain: String,
-    spares: u32,
-    maximum: u32,
-    service: Option<String>,
-    target_claim_delay: Option<u32>,
-    resolver: Option<R>
-}
-
+#[derive(Debug)]
 pub struct ConnectionPool<C, R> {
-    connections: Vec<C>,
+    protected_data: ProtectedData<C>,
     last_error: Option<Error>,
-    resolver: R,
-    stats: ConnectionPoolStats,
-    domain: String,
+    resolver_thread: Option<thread::JoinHandle<()>>,
+    resolver_rx_thread: Option<thread::JoinHandle<()>>,
     spares: u32,
     maximum: u32,
-    service: Option<String>,
-    target_claim_delay: u32
+    claim_timeout: Option<u64>,
+    log: Logger,
+    _resolver: PhantomData<R>
+}
+
+impl<C, R> Clone for ConnectionPool<C, R>
+where
+    C: Connection,
+    R: Resolver
+{
+    fn clone(&self) -> ConnectionPool<C, R> {
+        ConnectionPool {
+            protected_data: self.protected_data.clone(),
+            last_error: None,
+            resolver_thread: None,
+            resolver_rx_thread: None,
+            spares: self.spares.clone(),
+            maximum: self.maximum.clone(),
+            claim_timeout: self.claim_timeout.clone(),
+            log: self.log.clone(),
+            _resolver: PhantomData
+        }
+    }
 }
 
 impl<C, R> ConnectionPool<C, R>
@@ -41,27 +69,316 @@ where
     C: Connection,
     R: Resolver
 {
-    pub fn new(o: ConnectionPoolOptions<R>) -> Self {
+    pub fn new(cpo: ConnectionPoolOptions<R>) -> Self {
+        let connection_data = ConnectionData::new(cpo.maximum as usize);
+
+        // Create a channel to receive notifications from the resolver
+        let (tx, rx) = channel();
+
+        let barrier = Arc::new(Barrier::new(2));
+
+        let mut resolver = cpo.resolver;
+
+        // Spawn a thread to run the resolver
+        let barrier_clone = barrier.clone();
+        let resolver_thread = thread::spawn(move || {
+            // Wait until ConnectonPool is created
+            barrier_clone.wait();
+
+            resolver.start(tx);
+        });
+
+        let protected_data = ProtectedData::new(connection_data);
+
+        // Spawn another thread to receive notifications from resolver and take
+        // action
+        let protected_data_clone = protected_data.clone();
+        let max_connections = cpo.maximum.clone();
+        let log_clone = cpo.log.clone();
+        let resolver_rx_thread =
+            thread::spawn(move || resolver_recv_loop::<C>(rx, max_connections, protected_data_clone, log_clone));
+
+        let pool = ConnectionPool {
+            protected_data: protected_data,
+            last_error: None,
+            resolver_thread: Some(resolver_thread),
+            resolver_rx_thread: Some(resolver_rx_thread),
+            spares: cpo.spares,
+            maximum: cpo.maximum,
+            claim_timeout: cpo.claim_timeout,
+            log: cpo.log,
+            _resolver: PhantomData
+        };
+
+        barrier.clone().wait();
+        pool
+    }
+
+    pub fn stop(&self) -> () {
         std::unimplemented!()
     }
 
-    pub fn stop() -> () {
+    pub fn claim(&self) -> Result<PoolConnection<C, R>, Error> {
+        let mut connection_data_guard = self.protected_data.connection_data_lock();
+        let mut connection_data = connection_data_guard.deref_mut();
+        let mut waiting_for_connection = true;
+        let mut result = Err(Error::CueballError(String::from("dummy error")));
+
+        while waiting_for_connection {
+            if connection_data.stats.idle_connections > 0 {
+                match connection_data.connections.pop_front() {
+                    Some(ConnectionKeyPair((key, Some(conn)))) => {
+                        connection_data.stats.idle_connections =
+                            connection_data.stats.idle_connections - 1;
+                        waiting_for_connection = false;
+                        result =
+                            Ok(PoolConnection {
+                                connection_pool: self.clone(),
+                                connection_pair: ConnectionKeyPair((key, Some(conn)))
+                            });
+                    },
+                    Some(ConnectionKeyPair((_key, None))) => {
+                        // Should never happen
+                        let err_msg = String::from("Found backend key with no connection");
+                        warn!(self.log, "{}", err_msg);
+                        result = Err(Error::CueballError(err_msg));
+                    },
+                    None => {
+                        let err_msg = String::from("Unable to retrieve a connection");
+                        result = Err(Error::CueballError(err_msg));
+                    }
+                }
+            } else{
+                let wait_result =
+                    self.protected_data.condvar_wait(connection_data_guard,
+                                                     self.claim_timeout);
+                connection_data_guard = wait_result.0;
+                connection_data = connection_data_guard.deref_mut();
+
+                if wait_result.1 {
+                    let err_msg = String::from("Unable to retrieve a \
+                                                connection within the \
+                                                claim timeout");
+                    result = Err(Error::CueballError(err_msg));
+                    waiting_for_connection = false;
+                }
+            }
+        }
+
+        return result;
+    }
+
+    pub fn try_claim(&self) -> Option<PoolConnection<C, R>> {
+        let mut connection_data = self.protected_data.connection_data_lock();
+
+        if connection_data.stats.idle_connections > 0 {
+            match connection_data.connections.pop_front() {
+                Some(ConnectionKeyPair((key, Some(conn)))) => {
+                    connection_data.stats.idle_connections =
+                        connection_data.stats.idle_connections - 1;
+                    Some(PoolConnection {
+                        connection_pool: self.clone(),
+                        connection_pair: ConnectionKeyPair((key, Some(conn)))
+                    })
+                },
+                Some(ConnectionKeyPair((_key, None))) => {
+                    // Should never happen
+                    let err_msg = String::from("Found backend key with no connection");
+                    warn!(self.log, "{}", err_msg);
+                    None
+                },
+                None => {
+                    None
+                }
+            }
+        } else {
+            None
+        }
+    }
+
+    pub fn get_last_error(&self) -> Option<String> {
         std::unimplemented!()
     }
 
-    pub fn claim() -> Result<C, Error> {
+    pub fn get_stats(&self) -> Option<ConnectionPoolStats> {
         std::unimplemented!()
     }
 
-    pub fn try_claim() -> Option<C> {
-        std::unimplemented!()
-    }
+    fn replace(&self, connection_key_pair: ConnectionKeyPair<C>)
+    where
+        C: Connection
+    {
+        let mut connection_data = self.protected_data.connection_data_lock();
+        let (key, m_conn) = connection_key_pair.into();
 
-    pub fn get_last_error() -> Option<String> {
-        std::unimplemented!()
-    }
+        if connection_data.dead_connection_keys.contains(&key) {
+            // Connection was removed by resolver so close it and remove from
+            // dead_connection_keys set
+            match m_conn {
+                Some(mut conn) => {
+                    log_error(&self.log, conn.close())
+                },
+                None => {
+                    // Should never get here
+                    let err_msg = String::from("Found backend key with no connection");
+                    warn!(self.log, "{}", err_msg);
+                    ()
+                }
+            }
 
-    pub fn get_stats() -> Option<ConnectionPoolStats> {
-        std::unimplemented!()
+            let _ = connection_data.dead_connection_keys.remove(&key);
+        } else {
+            connection_data.connections.push_back((key, m_conn).into());
+            connection_data.stats.idle_connections =
+                connection_data.stats.idle_connections + 1;
+            self.protected_data.condvar_notify();
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct PoolConnection<C, R>
+where
+    C: Connection,
+    R: Resolver
+{
+    connection_pool: ConnectionPool<C, R>,
+    connection_pair: ConnectionKeyPair<C>
+}
+
+impl<C, R> Drop for PoolConnection<C, R>
+where
+    C: Connection,
+    R: Resolver
+{
+    fn drop(&mut self) {
+        let ConnectionKeyPair((key, m_conn)) = &mut self.connection_pair;
+        match m_conn.take() {
+            Some(conn) => {
+                self.connection_pool.replace((key.clone(), Some(conn)).into());
+            },
+            None => {
+                // If we arrive here then the connection is no longer available
+                // and cannot be returned to the pool
+                // TODO: Log this case
+            }
+        }
+    }
+}
+
+
+fn log_error(log: &Logger, result: Result<(), Error>) {
+    if let Err(err) = result {
+        let err_str = format!("{}", err);
+        error!(log, "{}", err_str);
+        ()
+    }
+}
+
+fn add_backend<C>(msg: BackendAddedMsg,
+                     max_connections: &u32,
+                     protected_data: ProtectedData<C>)
+                     -> Result<(), Error>
+where
+    C: Connection
+{
+    // Check if we already have enough connections
+    let mut connection_data = protected_data.connection_data_lock();
+
+    // TODO: Account for spares
+    if connection_data.stats.total_connections < *max_connections {
+        // Try to establish connection
+        let mut conn = C::new(&msg.backend);
+        conn.connect().and_then(|_| {
+            // Update connection info and stats
+            let connection_key_pair =(msg.key.clone(), Some(conn)).into();
+            connection_data.connections.push_back(connection_key_pair);
+            connection_data.stats.idle_connections =
+                connection_data.stats.idle_connections + 1;
+            connection_data.stats.total_connections =
+                connection_data.stats.total_connections + 1;
+
+            protected_data.condvar_notify();
+
+            Ok(())
+        })
+    } else {
+        let err_msg = String::from("Maximum connection count already reached");
+        Err(Error::CueballError(err_msg))
+    }
+}
+
+
+fn remove_backend<C>(msg: BackendRemovedMsg,
+                     protected_data: ProtectedData<C>,
+                     log: &Logger)
+                     -> Result<(), Error>
+where
+    C: Connection
+{
+    let mut connection_data = protected_data.connection_data_lock();
+
+    connection_data.stats.total_connections =
+        connection_data.stats.total_connections - 1;
+
+    // Find the index of the connection key pair. Use a fake connection key pair
+    // that only contains the key of interest. The custom Eq and PartialEq
+    // instances dictate that equality is solely determined by the first member
+    // of the pair.
+    let fake_connection_key_pair = (msg.0.clone(), None).into();
+    let m_pos = connection_data
+        .connections
+        .iter()
+        .position(|x| *x == fake_connection_key_pair);
+
+    match m_pos {
+        Some(pos) => {
+            // Remove the connection from the connections queue and close it
+            let remove_result =
+                connection_data.connections.remove(pos)
+                .and_then(|ConnectionKeyPair((_key, m_conn))| m_conn)
+                .ok_or_else(|| {
+                    // Should never happen
+                    let err_msg = String::from("Found backend key with no connection");
+                    warn!(log, "{}", err_msg);
+                    Error::CueballError(err_msg)
+                })
+                .and_then(|mut conn| conn.close());
+
+            log_error(&log, remove_result);
+
+            // Update idle connections count
+            connection_data.stats.idle_connections =
+                connection_data.stats.idle_connections - 1;
+        },
+        None => {
+            // Connection is in use so add to dead connections queue
+            connection_data.dead_connection_keys.insert(msg.0.clone());
+        }
+    }
+    Ok(())
+}
+
+fn resolver_recv_loop<C>(rx: Receiver<BackendMsg>,
+                         max_connections: u32,
+                         protected_data: ProtectedData<C>,
+                         log: Logger)
+where
+    C: Connection
+{
+    let mut done = false;
+    while !done {
+        let result =
+            match rx.recv() {
+                Ok(BackendMsg::AddedMsg(added_msg)) =>
+                    add_backend::<C>(added_msg, &max_connections, protected_data.clone()),
+                Ok(BackendMsg::RemovedMsg(removed_msg)) =>
+                    remove_backend::<C>(removed_msg, protected_data.clone(), &log),
+                Err(_recv_err) => {
+                    done = true;
+                    Ok(())
+                }
+            };
+        log_error(&log, result);
     }
 }

--- a/src/connection_pool/types.rs
+++ b/src/connection_pool/types.rs
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2019 Joyent, Inc.
+ */
+
+use std::cmp::Ordering;
+use std::collections::{HashSet, VecDeque};
+use std::sync::{Arc, Condvar, Mutex, MutexGuard};
+use std::time::Duration;
+
+use slog::Logger;
+
+use crate::backend::BackendKey;
+use crate::connection::Connection;
+
+
+#[derive(Copy, Clone, Debug)]
+pub struct ConnectionPoolStats {
+    pub total_connections: u32,
+    pub idle_connections: u32,
+    pub pending_connections: u32
+}
+
+impl ConnectionPoolStats {
+    pub fn new() -> Self {
+        ConnectionPoolStats {
+            total_connections: 0,
+            idle_connections: 0,
+            pending_connections: 0
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct ConnectionPoolOptions<R> {
+    pub domain: String,
+    pub spares: u32,
+    pub maximum: u32,
+    pub service: Option<String>,
+    pub claim_timeout: Option<u64>,
+    pub resolver: R,
+    pub log: Logger
+}
+
+#[derive(Clone, Debug)]
+pub struct ConnectionKeyPair<C>(pub (BackendKey, Option<C>));
+
+impl<C> PartialEq for ConnectionKeyPair<C>
+where
+    C: Connection
+{
+    fn eq(&self, other: &ConnectionKeyPair<C>) -> bool {
+        (self.0).0 == (other.0).0
+    }
+}
+
+impl<C> Eq for ConnectionKeyPair<C>
+where
+    C: Connection
+{}
+
+impl<C> Ord for ConnectionKeyPair<C>
+where
+    C: Connection
+{
+    fn cmp(&self, other: &ConnectionKeyPair<C>) -> Ordering {
+        (self.0).0.cmp(&(other.0).0)
+    }
+}
+
+impl<C> PartialOrd for ConnectionKeyPair<C>
+where
+    C: Connection
+{
+    fn partial_cmp(&self, other: &ConnectionKeyPair<C>) -> Option<Ordering> {
+        (self.0).0.partial_cmp(&(other.0).0)
+    }
+}
+
+impl<C> From<(BackendKey, C)> for ConnectionKeyPair<C>
+where
+    C: Connection
+{
+    fn from(pair: (BackendKey, C)) -> Self {
+        ConnectionKeyPair((pair.0, Some(pair.1)))
+    }
+}
+
+impl<C> From<(BackendKey, Option<C>)> for ConnectionKeyPair<C>
+where
+    C: Connection
+{
+    fn from(pair: (BackendKey, Option<C>)) -> Self {
+        ConnectionKeyPair((pair.0, pair.1))
+    }
+}
+
+impl<C> Into<(BackendKey, Option<C>)> for ConnectionKeyPair<C>
+where
+    C: Connection
+{
+    fn into(self) -> (BackendKey, Option<C>) {
+        ((self.0).0, (self.0).1)
+    }
+}
+
+
+#[derive(Clone, Debug)]
+pub struct ConnectionData<C> {
+    pub connections: VecDeque<ConnectionKeyPair<C>>,
+    pub stats: ConnectionPoolStats,
+    pub dead_connection_keys: HashSet<BackendKey>
+}
+
+impl<C> ConnectionData<C>
+where
+    C: Connection
+{
+    pub fn new(max_size: usize) -> Self {
+        ConnectionData {
+            connections: VecDeque::with_capacity(max_size),
+            stats: ConnectionPoolStats::new(),
+            dead_connection_keys: HashSet::with_capacity(max_size)
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct ProtectedData<C>(Arc<(Mutex<ConnectionData<C>>, Condvar)>);
+
+impl<C> ProtectedData<C>
+where
+    C: Connection
+{
+    pub fn new(connection_data: ConnectionData<C>) -> Self {
+        ProtectedData(Arc::new((Mutex::new(connection_data), Condvar::new())))
+    }
+
+    pub fn connection_data_lock(&self) -> MutexGuard<ConnectionData<C>> {
+        (self.0).0.lock().unwrap()
+    }
+
+    pub fn condvar_wait<'a>(&self, g: MutexGuard<'a, ConnectionData<C>>, m_timeout_ms: Option<u64>)
+                        -> (MutexGuard<'a, ConnectionData<C>>, bool)
+    {
+        match m_timeout_ms {
+            Some(timeout_ms) => {
+                let timeout = Duration::from_millis(timeout_ms);
+                let wait_result = (self.0).1.wait_timeout(g, timeout).unwrap();
+                (wait_result.0, wait_result.1.timed_out())
+            },
+            None => ((self.0).1.wait(g).unwrap(), false)
+        }
+    }
+
+    pub fn condvar_notify(&self) {
+        (self.0).1.notify_one()
+    }
+}
+
+impl<C> Clone for ProtectedData<C>
+where
+    C: Connection
+{
+    fn clone(&self) -> ProtectedData<C> {
+        ProtectedData(Arc::clone(&self.0))
+    }
+}
+
+impl<C> Into<Arc<(Mutex<ConnectionData<C>>, Condvar)>> for ProtectedData<C>
+where
+    C: Connection
+{
+    fn into(self) -> Arc<(Mutex<ConnectionData<C>>, Condvar)> {
+        self.0
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,6 +2,9 @@
  * Copyright 2019 Joyent, Inc.
  */
 
+use std::fmt;
+
+#[derive(Debug)]
 pub enum Error {
     CueballError(String),
     IOError(std::io::Error)
@@ -10,5 +13,14 @@ pub enum Error {
 impl From<std::io::Error> for Error {
     fn from(error: std::io::Error) -> Self {
         Error::IOError(error)
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Error::CueballError(err_str) => err_str.fmt(fmt),
+            Error::IOError(io_err) => io_err.fmt(fmt)
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,9 @@
 //! a multi-node service. Information about the available service nodes to
 //! connect to is provided by implementors of the Resolver trait.
 
+pub mod backend;
 pub mod connection;
+#[allow(dead_code)] // TODO: Remove after initial dev
 pub mod connection_pool;
 pub mod error;
 pub mod resolver;

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -4,10 +4,22 @@
 
 use std::sync::mpsc::Sender;
 
-pub trait Resolver: Send + Sync
-{
-    fn new (&self, s: Sender<String>) -> Self;
-    fn start(&self) -> ();
-    fn stop(&self) -> ();
+use crate::backend;
+
+pub trait Resolver: Send + 'static {
+    fn start (&mut self, s: Sender<BackendMsg>);
+    fn stop(&mut self);
     fn get_last_error(&self) -> Option<String>;
+}
+
+pub struct BackendAddedMsg {
+    pub key: backend::BackendKey,
+    pub backend: backend::Backend
+}
+
+pub struct BackendRemovedMsg(pub backend::BackendKey);
+
+pub enum BackendMsg {
+    AddedMsg(BackendAddedMsg),
+    RemovedMsg(BackendRemovedMsg)
 }

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -23,3 +23,8 @@ pub enum BackendMsg {
     AddedMsg(BackendAddedMsg),
     RemovedMsg(BackendRemovedMsg)
 }
+
+pub enum BackendAction {
+    BackendAdded,
+    BackendRemoved
+}


### PR DESCRIPTION
I'm submitting these changes for review even though there is still work to be done. I have some basic functionality working and I think it's worth merging this in while continuing the work. 

This work implements most of the basic cueball functionality. A connection pool can be configured and started. This must include an implementation of the `Resolver` trait to use as well as an implementation of the `Connection` trait that will compose the pool members. The resolver runs in its own thread and communicates over a channel with the main connection pool thread when backends are added or removed. I have implemented connection rebalancing. This happens when a backend is added or removed with a slight delay to avoid unnecessary churn when multiple backends come or go in a short period of time.

There are some things still not done such as stopping the pool, but the idea for this change is to get other eyes on the code and test out the API. There is a an example program included here to show how the pool can be used and also a basic test to verify the connection claim functionality. It still needs much more documentation so please raise any questions and I'll be happy to help if something isn't clear.