### PR TITLE
Update the Connection trait interface

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -28,7 +28,7 @@ pub struct Backend {
     /// The address of the backend.
     pub address: BackendAddress,
     /// The port of the backend.
-    pub port: BackendPort
+    pub port: BackendPort,
 }
 
 impl Backend {
@@ -37,7 +37,7 @@ impl Backend {
         Backend {
             name: backend_name(address, port),
             address: *address,
-            port
+            port,
         }
     }
 }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -2,7 +2,6 @@
  * Copyright 2019 Joyent, Inc.
  */
 
-use crate::backend::Backend;
 use crate::error::Error;
 
 /// Cueball connection
@@ -11,13 +10,14 @@ use crate::error::Error;
 /// order to participate in a Cueball connection pool. A connection need not be
 /// limited to a TCP socket, but could be any logical notion of a connection
 /// that implements the `Connection` trait.
-pub trait Connection: Send + Sync + Sized + 'static {
-    /// Returns a new `Connection` instance given a reference to an instance of
-    /// `Backend`.
-    fn new(b: &Backend) -> Self;
-    /// Attempt to establish the connection to the backend provided in the
-    /// [`new`]: #method.new call. Returns an [`error`]: ../enum.Error.html if
-    /// the connection attempt fails.
+pub trait Connection: Send + Sized + 'static {
+    /// Attempt to establish the connection to a backend. `Connection` trait
+    /// implementors are provided with details about the backend when the
+    /// `create_connection` function is invoked by the connection pool upon
+    /// notification by the `Resolver` that a new backend is available. The
+    /// `create_connection` function is provided to the connection pool via the
+    /// input parameters to `ConnectionPool::new`. Returns an [`error`]:
+    /// ../enum.Error.html if the connection attempt fails.
     fn connect(&mut self) -> Result<(), Error>;
     /// Close the connection to the backend
     fn close(&mut self) -> Result<(), Error>;

--- a/src/connection_pool.rs
+++ b/src/connection_pool.rs
@@ -16,14 +16,16 @@ use std::{thread, time};
 
 use slog::{debug, error, info, warn, Logger};
 
-use crate::backend::BackendKey;
+use crate::backend::{Backend, BackendKey};
 use crate::connection::Connection;
 use crate::connection_pool::types::{
-    ConnectionCount, ConnectionData, ConnectionKeyPair, ConnectionPoolOptions, ConnectionPoolState,
-    ConnectionPoolStats, ProtectedData, RebalanceCheck,
+    ConnectionCount, ConnectionData, ConnectionKeyPair, ConnectionPoolOptions,
+    ConnectionPoolState, ConnectionPoolStats, ProtectedData, RebalanceCheck
 };
 use crate::error::Error;
-use crate::resolver::{BackendAction, BackendAddedMsg, BackendMsg, BackendRemovedMsg, Resolver};
+use crate::resolver::{
+    BackendAction, BackendAddedMsg, BackendMsg, BackendRemovedMsg, Resolver
+};
 
 // General TODOs
 // * Decoherence
@@ -32,7 +34,8 @@ const DEFAULT_REBALANCE_ACTION_DELAY: u64 = 100;
 
 /// A pool of connections to a multi-node service
 #[derive(Debug)]
-pub struct ConnectionPool<C, R> {
+pub struct ConnectionPool<C, R, F>
+{
     protected_data: ProtectedData<C>,
     last_error: Option<Error>,
     resolver_thread: Option<thread::JoinHandle<()>>,
@@ -45,15 +48,17 @@ pub struct ConnectionPool<C, R> {
     rebalancer_stop: Arc<AtomicBool>,
     log: Logger,
     state: ConnectionPoolState,
-    _resolver: PhantomData<R>
+    _resolver: PhantomData<R>,
+    _connection_function: PhantomData<F>
 }
 
-impl<C, R> Clone for ConnectionPool<C, R>
+impl<C, R, F> Clone for ConnectionPool<C, R, F>
 where
     C: Connection,
     R: Resolver,
+    F: FnMut(&Backend) -> C + Send + Sync
 {
-    fn clone(&self) -> ConnectionPool<C, R> {
+    fn clone(&self) -> ConnectionPool<C, R, F> {
         ConnectionPool {
             protected_data: self.protected_data.clone(),
             last_error: None,
@@ -67,17 +72,23 @@ where
             rebalancer_stop: self.rebalancer_stop.clone(),
             log: self.log.clone(),
             state: self.state,
-            _resolver: PhantomData
+            _resolver: PhantomData,
+            _connection_function: PhantomData
         }
     }
 }
 
-impl<C, R> ConnectionPool<C, R>
+impl<C, R, F> ConnectionPool<C, R, F>
 where
     C: Connection,
     R: Resolver,
+    F: FnMut(&Backend) -> C + Send + Sync + 'static
 {
-    pub fn new(cpo: ConnectionPoolOptions<R>) -> Self {
+    pub fn new(
+        cpo: ConnectionPoolOptions,
+        mut resolver: R,
+        create_connection: F
+    ) -> Self {
         let connection_data = ConnectionData::new(cpo.maximum as usize);
 
         // Create a channel to receive notifications from the resolver. The
@@ -90,7 +101,7 @@ where
 
         let barrier = Arc::new(Barrier::new(2));
 
-        let mut resolver = cpo.resolver;
+        // let mut resolver = cpo.resolver;
 
         // Spawn a thread to run the resolver
         let barrier_clone = barrier.clone();
@@ -116,7 +127,7 @@ where
                 resolver_rx,
                 protected_data_clone,
                 rebalancer_clone,
-                resolver_log_clone
+                resolver_log_clone,
             )
         });
 
@@ -138,7 +149,8 @@ where
                 protected_data_clone2,
                 rebalancer_clone2,
                 rebalancer_log_clone,
-                rebalancer_stop_clone
+                rebalancer_stop_clone,
+                create_connection,
             )
         });
 
@@ -155,7 +167,8 @@ where
             rebalancer_stop,
             log: cpo.log,
             state: ConnectionPoolState::Running,
-            _resolver: PhantomData
+            _resolver: PhantomData,
+            _connection_function: PhantomData
         };
 
         barrier.clone().wait();
@@ -295,7 +308,7 @@ where
         }
     }
 
-    pub fn claim(&self) -> Result<PoolConnection<C, R>, Error> {
+    pub fn claim(&self) -> Result<PoolConnection<C, R, F>, Error> {
         let mut connection_data_guard = self.protected_data.connection_data_lock();
         let mut connection_data = connection_data_guard.deref_mut();
         let mut waiting_for_connection = true;
@@ -341,7 +354,7 @@ where
                             waiting_for_connection = false;
                             result = Ok(PoolConnection {
                                 connection_pool: self.clone(),
-                                connection_pair: ConnectionKeyPair((key, Some(conn))),
+                                connection_pair: ConnectionKeyPair((key, Some(conn)))
                             });
                         }
                     }
@@ -380,11 +393,11 @@ where
         result
     }
 
-    pub fn try_claim(&self) -> Option<PoolConnection<C, R>> {
+    pub fn try_claim(&self) -> Option<PoolConnection<C, R, F>> {
         let mut connection_data_guard = self.protected_data.connection_data_lock();
         let mut connection_data = connection_data_guard.deref_mut();
         let mut waiting_for_connection = true;
-        let mut result: Option<PoolConnection<C, R>> = None;
+        let mut result: Option<PoolConnection<C, R, F>> = None;
 
         let mut unwanted_connection_counts: HashMap<BackendKey, ConnectionCount> =
             connection_data.unwanted_connection_counts.drain().collect();
@@ -428,7 +441,7 @@ where
                             waiting_for_connection = false;
                             result = Some(PoolConnection {
                                 connection_pool: self.clone(),
-                                connection_pair: ConnectionKeyPair((key, Some(conn))),
+                                connection_pair: ConnectionKeyPair((key, Some(conn)))
                             });
                         }
                     }
@@ -486,19 +499,21 @@ where
 
 /// A connection abstraction reprsenting a member of the pool
 #[derive(Debug)]
-pub struct PoolConnection<C, R>
+pub struct PoolConnection<C, R, F>
 where
     C: Connection,
     R: Resolver,
+    F: FnMut(&Backend) -> C + Send + Sync + 'static
 {
-    connection_pool: ConnectionPool<C, R>,
-    connection_pair: ConnectionKeyPair<C>,
+    connection_pool: ConnectionPool<C, R, F>,
+    connection_pair: ConnectionKeyPair<C>
 }
 
-impl<C, R> Drop for PoolConnection<C, R>
+impl<C, R, F> Drop for PoolConnection<C, R, F>
 where
     C: Connection,
     R: Resolver,
+    F: FnMut(&Backend) -> C + Send + Sync
 {
     fn drop(&mut self) {
         let ConnectionKeyPair((key, m_conn)) = &mut self.connection_pair;
@@ -543,7 +558,6 @@ fn add_backend<C>(msg: BackendAddedMsg, protected_data: ProtectedData<C>) -> Opt
 where
     C: Connection,
 {
-    // Check if we already have enough connections
     let mut connection_data = protected_data.connection_data_lock();
 
     if !connection_data.backends.contains_key(&msg.key) {
@@ -690,13 +704,15 @@ where
     }
 }
 
-fn add_connections<C>(
+fn add_connections<C, F>(
     connection_counts: HashMap<BackendKey, ConnectionCount>,
     max_connections: u32,
     log: &Logger,
     protected_data: ProtectedData<C>,
+    create_connection: &mut F
 ) where
     C: Connection,
+    F: FnMut(&Backend) -> C + Send + Sync
 {
     connection_counts.iter().for_each(|(b_key, b_count)| {
         for _ in 0..b_count.clone().into() {
@@ -727,7 +743,7 @@ fn add_connections<C>(
                 // Try to establish connection
                 let m_backend = connection_data.backends.get(b_key);
                 if let Some(backend) = m_backend {
-                    let mut conn = C::new(backend);
+                    let mut conn = create_connection(backend);
                     conn.connect()
                         .and_then(|_| {
                             // Update connection info and stats
@@ -807,15 +823,17 @@ fn resolver_recv_loop<C>(
     }
 }
 
-fn rebalancer_loop<C>(
+fn rebalancer_loop<C, F>(
     max_connections: u32,
     rebalance_action_delay: u64,
     protected_data: ProtectedData<C>,
     rebalance_check: RebalanceCheck,
     log: Logger,
     stop: Arc<AtomicBool>,
+    mut create_connection: F,
 ) where
     C: Connection,
+    F: FnMut(&Backend) -> C + Send + Sync
 {
     let mut done = stop.load(AtomicOrdering::Relaxed);
 
@@ -844,6 +862,7 @@ fn rebalancer_loop<C>(
                     max_connections,
                     &log,
                     protected_data.clone(),
+                    &mut create_connection,
                 )
             }
             *rebalance = false;

--- a/src/connection_pool/types.rs
+++ b/src/connection_pool/types.rs
@@ -22,7 +22,7 @@ pub struct ConnectionPoolStats {
     /// The count of idle connections in the pool
     pub idle_connections: ConnectionCount,
     /// The number of created, but not yet connected connections
-    pub pending_connections: ConnectionCount
+    pub pending_connections: ConnectionCount,
 }
 
 impl ConnectionPoolStats {
@@ -31,7 +31,7 @@ impl ConnectionPoolStats {
         ConnectionPoolStats {
             total_connections: ConnectionCount::from(0),
             idle_connections: ConnectionCount::from(0),
-            pending_connections: ConnectionCount::from(0)
+            pending_connections: ConnectionCount::from(0),
         }
     }
 }
@@ -45,21 +45,18 @@ impl Default for ConnectionPoolStats {
 /// The configuration options for a Cueball connection pool. This is required to
 /// instantiate a new connection pool.
 #[derive(Debug)]
-pub struct ConnectionPoolOptions<R> {
+pub struct ConnectionPoolOptions {
     /// The maximum number of connections to maintain in the connection pool.
     pub maximum: u32,
     /// An optional timeout for blocking calls to request a connection from the
     /// pool.
     pub claim_timeout: Option<u64>,
-    /// The implementation of [`Resolver`]: ../trait.Resolver.html that the
-    /// connection pool should use.
-    pub resolver: R,
     /// A `slog` logger instance.
     pub log: Logger,
     /// An optional delay time to avoid extra rebalancing work in case the
     /// resolver notifies the pool of multiple changes within a short
     /// period. The default is 100 milliseconds.
-    pub rebalancer_action_delay: Option<u64>
+    pub rebalancer_action_delay: Option<u64>,
 }
 
 // This type wraps a pair that associates a `BackendKey` with a connection of
@@ -127,8 +124,22 @@ where
 }
 
 /// A newtype wrapper around u32 used for counts of connections mainatained by the connection pool.
-#[derive( Add, AddAssign, Clone, Copy, Debug, Display, Eq, From, Into, Ord,
-    PartialOrd, PartialEq, Sub, SubAssign )]
+#[derive(
+    Add,
+    AddAssign,
+    Clone,
+    Copy,
+    Debug,
+    Display,
+    Eq,
+    From,
+    Into,
+    Ord,
+    PartialOrd,
+    PartialEq,
+    Sub,
+    SubAssign,
+)]
 pub struct ConnectionCount(u32);
 
 // The internal data structures used to manage the connection pool.
@@ -139,7 +150,7 @@ pub struct ConnectionData<C> {
     pub connections: VecDeque<ConnectionKeyPair<C>>,
     pub connection_distribution: HashMap<BackendKey, ConnectionCount>,
     pub unwanted_connection_counts: HashMap<BackendKey, ConnectionCount>,
-    pub stats: ConnectionPoolStats
+    pub stats: ConnectionPoolStats,
 }
 
 impl<C> ConnectionData<C>
@@ -153,7 +164,7 @@ where
             connections: VecDeque::with_capacity(max_size),
             connection_distribution: HashMap::with_capacity(max_size),
             unwanted_connection_counts: HashMap::with_capacity(max_size),
-            stats: ConnectionPoolStats::new()
+            stats: ConnectionPoolStats::new(),
         }
     }
 }
@@ -186,7 +197,7 @@ where
                 let wait_result = (self.0).1.wait_timeout(g, timeout).unwrap();
                 (wait_result.0, wait_result.1.timed_out())
             }
-            None => ((self.0).1.wait(g).unwrap(), false)
+            None => ((self.0).1.wait(g).unwrap(), false),
         }
     }
 
@@ -263,7 +274,7 @@ pub enum ConnectionPoolState {
     Stopping,
     /// The connection pool is stopped and is no longer accepting connection
     /// claim requests.
-    Stopped
+    Stopped,
 }
 
 impl fmt::Display for ConnectionPoolState {
@@ -271,7 +282,7 @@ impl fmt::Display for ConnectionPoolState {
         match self {
             ConnectionPoolState::Running => String::from("running").fmt(fmt),
             ConnectionPoolState::Stopping => String::from("stopping").fmt(fmt),
-            ConnectionPoolState::Stopped => String::from("stopped").fmt(fmt)
+            ConnectionPoolState::Stopped => String::from("stopped").fmt(fmt),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,7 +7,7 @@ use std::fmt;
 #[derive(Debug)]
 pub enum Error {
     CueballError(String),
-    IOError(std::io::Error)
+    IOError(std::io::Error),
 }
 
 impl From<std::io::Error> for Error {
@@ -20,7 +20,7 @@ impl fmt::Display for Error {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Error::CueballError(err_str) => err_str.fmt(fmt),
-            Error::IOError(io_err) => io_err.fmt(fmt)
+            Error::IOError(io_err) => io_err.fmt(fmt),
         }
     }
 }

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -49,7 +49,7 @@ pub enum BackendMsg {
     RemovedMsg(BackendRemovedMsg),
     // For internal pool use only
     #[doc(hidden)]
-    StopMsg
+    StopMsg,
 }
 
 /// Returned from the functions used by the connection pool to add or remove
@@ -58,5 +58,5 @@ pub enum BackendAction {
     /// Indicates a new backend was added by the connection pool.
     BackendAdded,
     /// Indicates an existing backend was removed by the connection pool.
-    BackendRemoved
+    BackendRemoved,
 }


### PR DESCRIPTION
Update the `Connection` trait interface to support a way for `Connection` trait
implementors to provide context-specific information needed to establish a
connection. An example of this is a database connection where the
context-specific information needed might include a username, a password, or a
database name. This removes the new function from the Connection trait and
instead requires a function used to initialize a connection be provided to the
`ConnectionPool` when it is created.