### PR TITLE
Generic error type for Connection trait

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -31,6 +31,8 @@ impl DummyConnection {
 }
 
 impl Connection for DummyConnection {
+    type Error = Error;
+
     fn connect(&mut self) -> Result<(), Error> {
         self.connected = true;
         Ok(())

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -2,7 +2,7 @@
  * Copyright 2019 Joyent, Inc.
  */
 
-use crate::error::Error;
+use std::error;
 
 /// Cueball connection
 ///
@@ -10,7 +10,9 @@ use crate::error::Error;
 /// order to participate in a Cueball connection pool. A connection need not be
 /// limited to a TCP socket, but could be any logical notion of a connection
 /// that implements the `Connection` trait.
-pub trait Connection: Send + Sized + 'static {
+pub trait Connection: Send + Sized + 'static
+{
+    type Error: error::Error;
     /// Attempt to establish the connection to a backend. `Connection` trait
     /// implementors are provided with details about the backend when the
     /// `create_connection` function is invoked by the connection pool upon
@@ -18,7 +20,7 @@ pub trait Connection: Send + Sized + 'static {
     /// `create_connection` function is provided to the connection pool via the
     /// input parameters to `ConnectionPool::new`. Returns an [`error`]:
     /// ../enum.Error.html if the connection attempt fails.
-    fn connect(&mut self) -> Result<(), Error>;
+    fn connect(&mut self) -> Result<(), Self::Error>;
     /// Close the connection to the backend
-    fn close(&mut self) -> Result<(), Error>;
+    fn close(&mut self) -> Result<(), Self::Error>;
 }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -12,6 +12,16 @@ use std::error;
 /// that implements the `Connection` trait.
 pub trait Connection: Send + Sized + 'static
 {
+    /// The error type returned by the `connect` or `close` functions. This
+    /// is an associated type for the trait meaning each specific implementation
+    /// of the `Connection` trait may choose the appropriate concrete error type
+    /// to return. The only constraint applied is that the selected error type
+    /// must implement the
+    /// [Error](https://doc.rust-lang.org/std/error/trait.Error.html) trait from
+    /// the standard library. This allows for the error to relevant to the
+    /// context of the `Connection` implementation while avoiding unnecessary
+    /// type parameters or having to coerce data between incompatible error
+    /// types.
     type Error: error::Error;
     /// Attempt to establish the connection to a backend. `Connection` trait
     /// implementors are provided with details about the backend when the

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,6 +2,7 @@
  * Copyright 2019 Joyent, Inc.
  */
 
+use std::error::Error as StdError;
 use std::fmt;
 
 #[derive(Debug)]
@@ -21,6 +22,22 @@ impl fmt::Display for Error {
         match self {
             Error::CueballError(err_str) => err_str.fmt(fmt),
             Error::IOError(io_err) => io_err.fmt(fmt),
+        }
+    }
+}
+
+impl StdError for Error {
+    fn description(&self) -> &str {
+        match self {
+            Error::CueballError(desc) => desc.as_str(),
+            Error::IOError(io_err) => io_err.description()
+        }
+    }
+
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        match self {
+            Error::CueballError(_) => None,
+            Error::IOError(io_err) => Some(io_err)
         }
     }
 }

--- a/tests/basic_test.rs
+++ b/tests/basic_test.rs
@@ -31,6 +31,8 @@ impl DummyConnection {
 }
 
 impl Connection for DummyConnection {
+    type Error = Error;
+
     fn connect(&mut self) -> Result<(), Error> {
         self.connected = true;
         Ok(())


### PR DESCRIPTION
Use an associated type for errors returned by Connection trait functions. This
allows the concrete error types used by a Connection trait implementation to be
determined by the implementation rather than be specified by the cueball
connection pool.