### PR TITLE
Introduce health checks on connections to rust-cueball.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ authors = [
 edition = "2018"
 
 [dependencies]
+backoff = "0.1.5"
 base64 = "0.10.1"
 chrono = "0.4.7"
 periodic = "0.1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cueball"
-version = "0.2.2"
+version = "0.3.0"
 authors = [
         "Kelly McLaughlin <kelly.mclaughlin@joyent.com>",
         "Jon Anderson <jon.anderson@joyent.com>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cueball"
-version = "0.2.1"
+version = "0.2.2"
 authors = [
         "Kelly McLaughlin <kelly.mclaughlin@joyent.com>",
         "Jon Anderson <jon.anderson@joyent.com>",

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -3,8 +3,8 @@
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::mpsc::Sender;
 use std::sync::{Arc, Barrier, Mutex};
-use std::{thread, time};
 use std::time::Duration;
+use std::{thread, time};
 
 use slog::{info, o, Drain, Logger};
 
@@ -51,7 +51,7 @@ impl Connection for DummyConnection {
     fn is_valid(&mut self) -> bool {
         true
     }
-    fn has_broken(&mut self) -> bool {
+    fn has_broken(&self) -> bool {
         false
     }
 }
@@ -73,7 +73,7 @@ impl FakeResolver {
 }
 
 impl Resolver for FakeResolver {
-   fn run(&mut self, s: Sender<BackendMsg>) {
+    fn run(&mut self, s: Sender<BackendMsg>) {
         if self.running {
             return;
         }
@@ -90,8 +90,13 @@ impl Resolver for FakeResolver {
         self.pool_tx = Some(s);
 
         loop {
-            if self.pool_tx.as_ref().unwrap().send(BackendMsg::HeartbeatMsg).
-                is_err() {
+            if self
+                .pool_tx
+                .as_ref()
+                .unwrap()
+                .send(BackendMsg::HeartbeatMsg)
+                .is_err()
+            {
                 break;
             }
             thread::sleep(HEARTBEAT_INTERVAL);
@@ -122,6 +127,7 @@ fn main() {
         log: Some(log),
         rebalancer_action_delay: None,
         decoherence_interval: None,
+        connection_check_interval: None,
     };
 
     let pool = ConnectionPool::new(pool_opts, resolver, DummyConnection::new);

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -47,6 +47,13 @@ impl Connection for DummyConnection {
         self.connected = false;
         Ok(())
     }
+
+    fn is_valid(&mut self) -> bool {
+        true
+    }
+    fn has_broken(&mut self) -> bool {
+        false
+    }
 }
 
 pub struct FakeResolver {

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -47,13 +47,6 @@ impl Connection for DummyConnection {
         self.connected = false;
         Ok(())
     }
-
-    fn is_valid(&mut self) -> bool {
-        true
-    }
-    fn has_broken(&self) -> bool {
-        false
-    }
 }
 
 pub struct FakeResolver {

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -33,7 +33,7 @@ pub trait Connection: Send + Sized + 'static {
     /// connection is unhealthy.
     fn is_valid(&mut self) -> bool;
     // Check to see if the connection has closed or is not operational.
-    fn has_broken(&mut self) -> bool;
+    fn has_broken(&self) -> bool;
     /// Close the connection to the backend
     fn close(&mut self) -> Result<(), Self::Error>;
 }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -31,9 +31,13 @@ pub trait Connection: Send + Sized + 'static {
     /// check the to see if connection is still up and working. The connection pool runs this
     /// function as the connection is being replaced and triggers a rebalance if the
     /// connection is unhealthy.
-    fn is_valid(&mut self) -> bool;
+    fn is_valid(&mut self) -> bool {
+        true
+    }
     // Check to see if the connection has closed or is not operational.
-    fn has_broken(&self) -> bool;
+    fn has_broken(&self) -> bool {
+        false
+    }
     /// Close the connection to the backend
     fn close(&mut self) -> Result<(), Self::Error>;
 }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -28,6 +28,12 @@ pub trait Connection: Send + Sized + 'static {
     /// input parameters to `ConnectionPool::new`. Returns an [`error`](
     /// ../error/enum.Error.html) if the connection attempt fails.
     fn connect(&mut self) -> Result<(), Self::Error>;
+    /// check the to see if connection is still up and working. The connection pool runs this
+    /// function as the connection is being replaced and triggers a rebalance if the
+    /// connection is unhealthy.
+    fn is_valid(&mut self) -> bool;
+    // Check to see if the connection has closed or is not operational.
+    fn has_broken(&mut self) -> bool;
     /// Close the connection to the backend
     fn close(&mut self) -> Result<(), Self::Error>;
 }

--- a/src/connection_pool.rs
+++ b/src/connection_pool.rs
@@ -1162,7 +1162,7 @@ fn check_pool_connections<C>(
                         *e
                     );
                 })
-                .or_insert(ConnectionCount::from(*count));
+                .or_insert_with(|| ConnectionCount::from(*count));
         }
         connection_data.stats.idle_connections -= removed.into();
 

--- a/src/connection_pool.rs
+++ b/src/connection_pool.rs
@@ -13,7 +13,7 @@ use std::sync::{Arc, Barrier};
 use std::time::Duration;
 use std::{thread, time};
 
-use slog::{debug, error, info, o, trace, warn, Drain, Logger};
+use slog::{debug, error, info, o, warn, Drain, Logger};
 
 use crate::backend::{Backend, BackendKey};
 use crate::connection::Connection;

--- a/src/connection_pool.rs
+++ b/src/connection_pool.rs
@@ -338,7 +338,7 @@ where
             connection_data = self.protected_data.connection_data_lock();
             connection_data.stats.total_connections = 0.into();
 
-            // Move state too
+            // Move state to Stopped
             self.state = ConnectionPoolState::Stopped;
             Ok(())
         } else {

--- a/src/connection_pool.rs
+++ b/src/connection_pool.rs
@@ -55,9 +55,9 @@ pub struct ConnectionPool<C, R, F> {
     log: Logger,
     state: ConnectionPoolState,
     decoherence_timer: Option<timer::Timer>,
-    decoherence_timer_guard: Guard,
+    _decoherence_timer_guard: Option<Guard>,
     connection_check_timer: Option<timer::Timer>,
-    connection_check_timer_guard: Guard,
+    _connection_check_timer_guard: Option<Guard>,
     _resolver: PhantomData<R>,
     _connection_function: PhantomData<F>,
 }
@@ -135,11 +135,9 @@ where
             log: self.log.clone(),
             state: self.state,
             decoherence_timer: None,
-            decoherence_timer_guard: self.decoherence_timer_guard.clone(),
             connection_check_timer: None,
-            connection_check_timer_guard: self
-                .connection_check_timer_guard
-                .clone(),
+            _connection_check_timer_guard: None,
+            _decoherence_timer_guard: None,
             _resolver: PhantomData,
             _connection_function: PhantomData,
         }
@@ -266,9 +264,9 @@ where
             log: logger,
             state: ConnectionPoolState::Running,
             decoherence_timer: Some(decoherence_timer),
-            decoherence_timer_guard,
+            _decoherence_timer_guard: Some(decoherence_timer_guard),
             connection_check_timer: Some(connection_check_timer),
-            connection_check_timer_guard,
+            _connection_check_timer_guard: Some(connection_check_timer_guard),
             _resolver: PhantomData,
             _connection_function: PhantomData,
         };

--- a/src/connection_pool/types.rs
+++ b/src/connection_pool/types.rs
@@ -63,6 +63,10 @@ pub struct ConnectionPoolOptions {
     /// the period of the decoherence shuffle. If not specified the default is
     /// 300 seconds.
     pub decoherence_interval: Option<u64>,
+    /// Optional connection check interval in seconds. This represents the length of
+    /// the period of the pool connection check task. If not specified the default is
+    /// 30 seconds.
+    pub connection_check_interval: Option<u64>,
 }
 
 // This type wraps a pair that associates a `BackendKey` with a connection of

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -57,25 +57,19 @@ pub enum BackendMsg {
     // For internal pool use only. Resolver implementations can send this
     // message to test whether or not the channel has been closed.
     #[doc(hidden)]
-    HeartbeatMsg
+    HeartbeatMsg,
 }
 
 impl PartialEq for BackendMsg {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
-            (BackendMsg::AddedMsg(a), BackendMsg::AddedMsg(b)) => {
-                a == b
-            },
+            (BackendMsg::AddedMsg(a), BackendMsg::AddedMsg(b)) => a == b,
             (BackendMsg::RemovedMsg(a), BackendMsg::RemovedMsg(b)) => {
                 a.0 == b.0
-            },
-            (BackendMsg::StopMsg, BackendMsg::StopMsg) => {
-                true
-            },
-            (BackendMsg::HeartbeatMsg, BackendMsg::HeartbeatMsg) => {
-                true
-            },
-            _ => false
+            }
+            (BackendMsg::StopMsg, BackendMsg::StopMsg) => true,
+            (BackendMsg::HeartbeatMsg, BackendMsg::HeartbeatMsg) => true,
+            _ => false,
         }
     }
 }

--- a/tests/basic_test.rs
+++ b/tests/basic_test.rs
@@ -3,8 +3,8 @@
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::mpsc::Sender;
 use std::sync::{Arc, Barrier};
-use std::{thread, time};
 use std::time::Duration;
+use std::{thread, time};
 
 use cueball::backend;
 use cueball::backend::{Backend, BackendAddress, BackendPort};
@@ -44,6 +44,7 @@ impl Connection for DummyConnection {
     fn is_valid(&mut self) -> bool {
         true
     }
+
     fn has_broken(&mut self) -> bool {
         false
     }
@@ -88,8 +89,13 @@ impl Resolver for FakeResolver {
         self.pool_tx = Some(s);
 
         loop {
-            if self.pool_tx.as_ref().unwrap().send(BackendMsg::HeartbeatMsg).
-                is_err() {
+            if self
+                .pool_tx
+                .as_ref()
+                .unwrap()
+                .send(BackendMsg::HeartbeatMsg)
+                .is_err()
+            {
                 break;
             }
             thread::sleep(HEARTBEAT_INTERVAL);
@@ -114,6 +120,7 @@ fn connection_pool_claim() {
         log: None,
         rebalancer_action_delay: None,
         decoherence_interval: None,
+        connection_check_interval: None,
     };
 
     let max_connections = pool_opts.max_connections.unwrap().clone();
@@ -199,6 +206,7 @@ fn connection_pool_stop() {
         log: None,
         rebalancer_action_delay: None,
         decoherence_interval: None,
+        connection_check_interval: None,
     };
 
     let max_connections = pool_opts.max_connections.unwrap().clone();
@@ -238,6 +246,7 @@ fn connection_pool_accounting() {
         log: None,
         rebalancer_action_delay: None,
         decoherence_interval: None,
+        connection_check_interval: None,
     };
 
     let max_connections: ConnectionCount =
@@ -349,6 +358,7 @@ fn connection_pool_decoherence() {
         log: None,
         rebalancer_action_delay: Some(10000),
         decoherence_interval: Some(5),
+        connection_check_interval: None,
     };
 
     let max_connections: ConnectionCount =

--- a/tests/basic_test.rs
+++ b/tests/basic_test.rs
@@ -41,14 +41,6 @@ impl Connection for DummyConnection {
         Ok(())
     }
 
-    fn is_valid(&mut self) -> bool {
-        true
-    }
-
-    fn has_broken(&mut self) -> bool {
-        false
-    }
-
     fn close(&mut self) -> Result<(), Error> {
         self.connected = false;
         Ok(())

--- a/tests/basic_test.rs
+++ b/tests/basic_test.rs
@@ -41,6 +41,13 @@ impl Connection for DummyConnection {
         Ok(())
     }
 
+    fn is_valid(&mut self) -> bool {
+        true
+    }
+    fn has_broken(&mut self) -> bool {
+        false
+    }
+
     fn close(&mut self) -> Result<(), Error> {
         self.connected = false;
         Ok(())


### PR DESCRIPTION
Introduce the notion of health-checks to Boray, including:
- New traits `is_valid` and `has_broken` to be overriden by connectors (postgres for example) that use cueball, appropriate for the underlying connection type. These now include default implementations so dependencies should not be broken if they do not implement.
- Retries with exponential backoff at start up in the cueball connection pool.
- A separate thread that periodically (at configurable intervals) checks the health of the connection pool and culls out broken connections, and kicks off a rebalance.
- Retries with exponential backoff in the rebalance sequence for connections

To Do:
- Make the exponential backoff defaults configurable.

Dependent repos include
- buckets-mdapi
- rust-cueball-postgres-connection
- rust-cueball-manatee-primary-resolver
- cueball-static-resolver
- rust-cueball-tcp-stream-connection

