### PR TITLE
Update static-resolver crate version, and prep Cargo.toml files for publication

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,10 +202,11 @@ may be useful to anyone looking to get started with `cueball`:
 
 ### `Resolver` trait implementer
 
-* [`cueball-static-resolver`](https://github.com/joyent/rust-cueball-static-resolver)
+* [`cueball-static-resolver`](https://github.com/joyent/rust-cueball/resolvers/static-resolver)
+* [`cueball-static-resolver`](https://github.com/joyent/rust-cueball/resolvers/manatee-primary-resolver)
 * [`cueball-dns-resolver`](https://github.com/joyent/rust-cueball-dns-resolver)
 
 ### `Connection` trait implementer
 
-* [`cueball-tcp-stream-connection`](https://github.com/joyent/rust-cueball-tcp-stream-connection)
-* [`cueball-postgres-connection`](https://github.com/joyent/rust-cueball-postgres-connection)
+* [`cueball-tcp-stream-connection`](https://github.com/joyent/rust-cueball/connections/tcp-stream-connection)
+* [`cueball-postgres-connection`](https://github.com/joyent/rust-cueball/connections/postgres-connection)

--- a/connections/postgres-connection/Cargo.toml
+++ b/connections/postgres-connection/Cargo.toml
@@ -3,7 +3,7 @@ name = "cueball-postgres-connection"
 version = "0.3.0"
 authors = ["Kelly McLaughlin <kelly.mclaughlin@joyent.com>"]
 description = """
-This is an implementation of the cueball Connection trait forpostgres::Client from the rust-postgres crate.
+This is an implementation of the cueball Connection trait for postgres::Client from the rust-postgres crate.
 """
 repository = "https://github.com/joyent/rust-cueball"
 keywords = ["pool","joyent"]

--- a/connections/postgres-connection/Cargo.toml
+++ b/connections/postgres-connection/Cargo.toml
@@ -5,9 +5,10 @@ authors = ["Kelly McLaughlin <kelly.mclaughlin@joyent.com>"]
 description = """
 This is an implementation of the cueball Connection trait forpostgres::Client from the rust-postgres crate.
 """
-repository = "https://github.com/joyent/cueball"
+repository = "https://github.com/joyent/rust-cueball"
+keywords = ["pool","joyent"]
 readme = "../../README.md"
-license = "Mozilla"
+license = "MPL-2.0"
 edition = "2018"
 
 [dependencies]

--- a/connections/postgres-connection/Cargo.toml
+++ b/connections/postgres-connection/Cargo.toml
@@ -2,6 +2,12 @@
 name = "cueball-postgres-connection"
 version = "0.3.0"
 authors = ["Kelly McLaughlin <kelly.mclaughlin@joyent.com>"]
+description = """
+This is an implementation of the cueball Connection trait forpostgres::Client from the rust-postgres crate.
+"""
+repository = "https://github.com/joyent/cueball"
+readme = "../../README.md"
+license = "Mozilla"
 edition = "2018"
 
 [dependencies]

--- a/connections/tcp-stream-connection/Cargo.toml
+++ b/connections/tcp-stream-connection/Cargo.toml
@@ -5,9 +5,10 @@ authors = ["Kelly McLaughlin <kelly.mclaughlin@joyent.com>"]
 description = """
 This is an implementation of the cueball Connection trait for TcpStream from the rust standard library.
 """
-repository = "https://github.com/joyent/cueball"
+repository = "https://github.com/joyent/rust-cueball"
+keywords = ["pool","joyent"]
 readme = "../../README.md"
-license = "Mozilla"
+license = "MPL-2.0"
 edition = "2018"
 
 [dependencies]

--- a/connections/tcp-stream-connection/Cargo.toml
+++ b/connections/tcp-stream-connection/Cargo.toml
@@ -2,6 +2,12 @@
 name = "cueball-tcp-stream-connection"
 version = "0.3.0"
 authors = ["Kelly McLaughlin <kelly.mclaughlin@joyent.com>"]
+description = """
+This is an implementation of the cueball Connection trait for TcpStream from the rust standard library.
+"""
+repository = "https://github.com/joyent/cueball"
+readme = "../../README.md"
+license = "Mozilla"
 edition = "2018"
 
 [dependencies]

--- a/resolvers/manatee-primary-resolver/Cargo.toml
+++ b/resolvers/manatee-primary-resolver/Cargo.toml
@@ -3,7 +3,8 @@ name = "cueball-manatee-primary-resolver"
 version = "0.3.0"
 authors = ["Kelly McLaughlin <kelly.mclaughlin@joyent.com>", "Isaac Davis <isaac.davis@joyent.com>"]
 description = """
-This is an implementation of thecueball Resolver trait that provides a list of backends for use by the connection pool.
+An implementation of the cueball Resolver trait that is specific to the Joyent manatee project. It queries a zookeeper 
+cluster to determine the PostgreSQL replication primary from a set of PostgreSQL replication peers.
 """
 repository = "https://github.com/joyent/rust-cueball"
 keywords = ["pool","joyent"]

--- a/resolvers/manatee-primary-resolver/Cargo.toml
+++ b/resolvers/manatee-primary-resolver/Cargo.toml
@@ -5,9 +5,10 @@ authors = ["Kelly McLaughlin <kelly.mclaughlin@joyent.com>", "Isaac Davis <isaac
 description = """
 This is an implementation of thecueball Resolver trait that provides a list of backends for use by the connection pool.
 """
-repository = "https://github.com/joyent/cueball"
+repository = "https://github.com/joyent/rust-cueball"
+keywords = ["pool","joyent"]
 readme = "../../README.md"
-license = "Mozilla"
+license = "MPL-2.0"
 edition = "2018"
 
 [dependencies]

--- a/resolvers/manatee-primary-resolver/Cargo.toml
+++ b/resolvers/manatee-primary-resolver/Cargo.toml
@@ -2,6 +2,12 @@
 name = "cueball-manatee-primary-resolver"
 version = "0.3.0"
 authors = ["Kelly McLaughlin <kelly.mclaughlin@joyent.com>", "Isaac Davis <isaac.davis@joyent.com>"]
+description = """
+This is an implementation of thecueball Resolver trait that provides a list of backends for use by the connection pool.
+"""
+repository = "https://github.com/joyent/cueball"
+readme = "../../README.md"
+license = "Mozilla"
 edition = "2018"
 
 [dependencies]

--- a/resolvers/static-resolver/Cargo.toml
+++ b/resolvers/static-resolver/Cargo.toml
@@ -5,9 +5,10 @@ authors = ["Kelly McLaughlin <kelly.mclaughlin@joyent.com>"]
 description = """
 This is an implementation of the cueball Resolver trait that provides a static list of backends for use by the connection pool.
 """
-repository = "https://github.com/joyent/cueball"
+repository = "https://github.com/joyent/rust-cueball"
+keywords = ["pool","joyent"]
 readme = "../../README.md"
-license = "Mozilla"
+license = "MPL-2.0"
 edition = "2018"
 
 [dependencies]

--- a/resolvers/static-resolver/Cargo.toml
+++ b/resolvers/static-resolver/Cargo.toml
@@ -1,7 +1,13 @@
 [package]
 name = "cueball-static-resolver"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Kelly McLaughlin <kelly.mclaughlin@joyent.com>"]
+description = """
+This is an implementation of the cueball Resolver trait that provides a static list of backends for use by the connection pool.
+"""
+repository = "https://github.com/joyent/cueball"
+readme = "../../README.md"
+license = "Mozilla"
 edition = "2018"
 
 [dependencies]


### PR DESCRIPTION
Add license, description and repo fields to the workspace's Cargo.toml files

Bump the version of static-resolver to 0.3.0.