### PR TITLE
connection_pool lacks a Drop instance

### DIFF
--- a/cueball/CHANGES.md
+++ b/cueball/CHANGES.md
@@ -1,0 +1,15 @@
+# rust-cueball changelog
+
+Known issues:
+
+- [joyent/rust-cueball#24] Rebalance with no backends can cause a crash
+
+## not yet released
+
+- [joyent/rust-cueball#33] connection_pool lacks a Drop instance
+- Fixed some typos in the README
+
+## 0.3.0
+
+- First version published to crates.io
+- [joyent/rust-cueball#17] Introduce health checks on connections to rust-cueball.

--- a/cueball/examples/basic.rs
+++ b/cueball/examples/basic.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 Joyent, Inc.
+// Copyright 2020 Joyent, Inc.
 
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::mpsc::Sender;
@@ -117,7 +117,7 @@ fn main() {
     let pool_opts = ConnectionPoolOptions {
         max_connections: Some(3),
         claim_timeout: Some(1000),
-        log: Some(log),
+        log: Some(log.clone()),
         rebalancer_action_delay: None,
         decoherence_interval: None,
         connection_check_interval: None,
@@ -181,4 +181,6 @@ fn main() {
 
     let m_claim3 = pool.try_claim();
     assert!(m_claim3.is_some());
+
+    loop {}
 }


### PR DESCRIPTION
This was uncovered while investigating MANTA-4966. The `connection_pool` type needs a custom `Drop` instance so that a full cleanup of the pool resources is done when the `connection_pool` goes out of scope.