### PR TITLE
MANTA-4975 rust-cueball-manatee-primary-resolver should reconnect with

### DIFF
--- a/resolvers/manatee-primary-resolver/Cargo.toml
+++ b/resolvers/manatee-primary-resolver/Cargo.toml
@@ -13,11 +13,13 @@ license = "MPL-2.0"
 edition = "2018"
 
 [dependencies]
+backoff = "0.1.6"
 clap = "2.32"
 cueball = { path = "../../cueball", version = "0.3.0" }
 itertools = "0.8.0"
 failure = "0.1.5"
 futures = "0.1.28"
+lazy_static = "1.4.0"
 serde = { version ="1.0.102", features = ["derive"]}
 serde_json = "1.0.40"
 slog = { version = "2.4.1", features = [ "max_level_trace" ] }

--- a/resolvers/manatee-primary-resolver/Cargo.toml
+++ b/resolvers/manatee-primary-resolver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cueball-manatee-primary-resolver"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["Kelly McLaughlin <kelly.mclaughlin@joyent.com>", "Isaac Davis <isaac.davis@joyent.com>"]
 description = """
 An implementation of the cueball Resolver trait that is specific to the Joyent manatee project. It queries a zookeeper

--- a/resolvers/manatee-primary-resolver/src/lib.rs
+++ b/resolvers/manatee-primary-resolver/src/lib.rs
@@ -413,10 +413,13 @@ impl ResolverBackoff {
     fn next_backoff(&mut self) -> Duration {
         let backoff = &mut *self.backoff.lock().unwrap();
         //
-        // This should never fail because we set max_elapsed_time to `None`
-        // above.
+        // This should never fail because we set max_elapsed_time to `None` in
+        // ResolverBackoff::new().
         //
-        let next_backoff = backoff.next_backoff().unwrap();
+        let next_backoff = backoff.next_backoff().expect(
+            "next_backoff returned
+            None; max_elapsed_time has been reached erroneously",
+        );
 
         //
         // Notify the stability-tracking thread that an error has occurred
@@ -713,7 +716,9 @@ fn process_value(
             Ok(url) => match url.port() {
                 Some(port) => port,
                 None => {
-                    return Err(ResolverError::MissingZkData(ZkDataField::Port));
+                    return Err(ResolverError::MissingZkData(
+                        ZkDataField::Port,
+                    ));
                 }
             },
             Err(_) => {

--- a/resolvers/manatee-primary-resolver/src/lib.rs
+++ b/resolvers/manatee-primary-resolver/src/lib.rs
@@ -716,9 +716,7 @@ fn process_value(
             Ok(url) => match url.port() {
                 Some(port) => port,
                 None => {
-                    return Err(ResolverError::MissingZkData(
-                        ZkDataField::Port,
-                    ));
+                    return Err(ResolverError::MissingZkData(ZkDataField::Port));
                 }
             },
             Err(_) => {

--- a/resolvers/manatee-primary-resolver/src/lib.rs
+++ b/resolvers/manatee-primary-resolver/src/lib.rs
@@ -713,9 +713,7 @@ fn process_value(
             Ok(url) => match url.port() {
                 Some(port) => port,
                 None => {
-                    return Err(ResolverError::MissingZkData(
-                        ZkDataField::Port,
-                    ));
+                    return Err(ResolverError::MissingZkData(ZkDataField::Port));
                 }
             },
             Err(_) => {
@@ -932,8 +930,10 @@ impl ResolverCore {
         self,
         zk: ZooKeeper,
         loop_state: WatchLoopState,
-    ) -> impl Future<Item = Loop<NextAction, WatchLoopState>, Error = FailureError>
-           + Send {
+    ) -> impl Future<
+        Item = Loop<NextAction, WatchLoopState>,
+        Error = FailureError,
+    > + Send {
         let watcher = loop_state.watcher;
         let curr_event = loop_state.curr_event;
         let delay = loop_state.delay;

--- a/resolvers/manatee-primary-resolver/src/lib.rs
+++ b/resolvers/manatee-primary-resolver/src/lib.rs
@@ -932,10 +932,8 @@ impl ResolverCore {
         self,
         zk: ZooKeeper,
         loop_state: WatchLoopState,
-    ) -> impl Future<
-        Item = Loop<NextAction, WatchLoopState>,
-        Error = FailureError,
-    > + Send {
+    ) -> impl Future<Item = Loop<NextAction, WatchLoopState>, Error = FailureError>
+           + Send {
         let watcher = loop_state.watcher;
         let curr_event = loop_state.curr_event;
         let delay = loop_state.delay;

--- a/resolvers/manatee-primary-resolver/tests/connection_test.rs
+++ b/resolvers/manatee-primary-resolver/tests/connection_test.rs
@@ -16,11 +16,10 @@ use cueball::resolver::Resolver;
 #[cfg(target_os = "solaris")]
 use common::util::{
     self, TestContext, TestError, ZkStatus, RESOLVER_STARTUP_DELAY,
-    SLACK_DURATION,
 };
 #[cfg(target_os = "solaris")]
 use cueball_manatee_primary_resolver::{
-    common, ManateePrimaryResolver, RECONNECT_DELAY, TCP_CONNECT_TIMEOUT,
+    common, ManateePrimaryResolver, MAX_BACKOFF_INTERVAL,
 };
 
 #[cfg(target_os = "solaris")]
@@ -64,9 +63,9 @@ fn connection_test_start_with_unreachable_zookeeper() {
 
         //
         // Wait the maximum possible amount of time that could elapse without
-        // the resolver reconnecting, plus a little extra to be safe.
+        // the resolver reconnecting
         //
-        thread::sleep(RECONNECT_DELAY + TCP_CONNECT_TIMEOUT + SLACK_DURATION);
+        thread::sleep(*MAX_BACKOFF_INTERVAL);
 
         // Check that the resolver has reconnected
         let connected = ctx.resolver_connected(&rx)?;
@@ -130,7 +129,7 @@ fn connection_test_reconnect_after_zk_hiccup() {
         // Wait the maximum possible amount of time that could elapse without
         // the resolver reconnecting, plus a little extra to be safe.
         //
-        thread::sleep(RECONNECT_DELAY + TCP_CONNECT_TIMEOUT + SLACK_DURATION);
+        thread::sleep(*MAX_BACKOFF_INTERVAL);
 
         // Check that the resolver has reconnected
         let connected = ctx.resolver_connected(&rx)?;

--- a/resolvers/manatee-primary-resolver/tests/watch_test.rs
+++ b/resolvers/manatee-primary-resolver/tests/watch_test.rs
@@ -14,7 +14,7 @@ use cueball::resolver::Resolver;
 use cueball_manatee_primary_resolver::common::{test_data, util};
 #[cfg(target_os = "solaris")]
 use cueball_manatee_primary_resolver::{
-    ManateePrimaryResolver, WATCH_LOOP_DELAY,
+    ManateePrimaryResolver, MAX_BACKOFF_INTERVAL,
 };
 #[cfg(target_os = "solaris")]
 use util::{TestAction, TestContext, RESOLVER_STARTUP_DELAY};
@@ -48,7 +48,7 @@ fn watch_test_nonexistent_node() {
         ctx.setup_zk_nodes()?;
 
         // Wait for resolver to notice that the node now exists
-        thread::sleep(WATCH_LOOP_DELAY);
+        thread::sleep(*MAX_BACKOFF_INTERVAL);
 
         // Run a basic test case to make sure all is well
         let data_1 = test_data::backend_ip1_port1();
@@ -108,7 +108,7 @@ fn watch_test_disappearing_node() {
         ctx.setup_zk_nodes()?;
 
         // Wait for resolver to notice that the nodes were recreated
-        thread::sleep(WATCH_LOOP_DELAY);
+        thread::sleep(*MAX_BACKOFF_INTERVAL);
 
         // Run the test case again
         ctx.run_test_case(


### PR DESCRIPTION
random timeout instead of fixed
MANTA-4896 Add exponential backoff logic for reconnecting to zookeeper
in either the manatee primary resolver or the zookeeper client library

Note that I had to call next_backoff() manually, rather than just wrap the whole thing in backoff::retry(), because everything takes place in an asynchronous context and backoff::retry() expects a synchronous operation as its argument.

See ticket for testing notes.