### PR TITLE
Fix and test for issue #24, divide by zero with no backend panic

### DIFF
--- a/cueball/src/connection_pool.rs
+++ b/cueball/src/connection_pool.rs
@@ -802,8 +802,8 @@ where
     let backend_count = connection_data.backends.len();
     info!(log, "Backend count: {}", &backend_count);
     if backend_count == 0 {
-       warn!(log, "Not running rebalance, no backends.");
-       return Ok(None)
+        warn!(log, "Not running rebalance, no backends.");
+        return Ok(None);
     }
 
     // Calculate a new connection distribution over the set of available

--- a/cueball/src/connection_pool.rs
+++ b/cueball/src/connection_pool.rs
@@ -799,6 +799,13 @@ where
         connection_data.connections.len()
     );
 
+    let backend_count = connection_data.backends.len();
+    info!(log, "Backend count: {}", &backend_count);
+    if backend_count == 0 {
+       warn!(log, "Not running rebalance, no backends.");
+       return Ok(None)
+    }
+
     // Calculate a new connection distribution over the set of available
     // backends and determine what additional connections need to be created and
     // what connections can be deemed unwanted.
@@ -831,8 +838,6 @@ where
 
     // Calculate the new connection distribution counts for the available
     // backends
-    let backend_count = connection_data.backends.len();
-    info!(log, "Backend count: {}", &backend_count);
     let connections_per_backend = max_connections as usize / backend_count;
     let mut connections_per_backend_rem =
         max_connections as usize % backend_count;

--- a/cueball/tests/basic_test.rs
+++ b/cueball/tests/basic_test.rs
@@ -405,7 +405,7 @@ fn connection_pool_no_backends() {
     let sleep_time = time::Duration::from_millis(5000);
     thread::sleep(sleep_time);
 
-    // we should only get here if the pool rebalance panics due 
-    // to divide-by-zero
+    // we should only get here if the pool rebalance does not panic because 
+    // there are no connections.
     assert!(true);
 }

--- a/cueball/tests/basic_test.rs
+++ b/cueball/tests/basic_test.rs
@@ -387,7 +387,6 @@ fn connection_pool_decoherence() {
 
 #[test]
 fn connection_pool_no_backends() {
-   
     let resolver = FakeResolver::new(vec![]);
 
     let pool_opts = ConnectionPoolOptions {
@@ -405,7 +404,6 @@ fn connection_pool_no_backends() {
     let sleep_time = time::Duration::from_millis(5000);
     thread::sleep(sleep_time);
 
-    // we should only get here if the pool rebalance does not panic because 
-    // there are no connections.
+    // we should only get here if the pool rebalance does not panic
     assert!(true);
 }

--- a/cueball/tests/basic_test.rs
+++ b/cueball/tests/basic_test.rs
@@ -384,3 +384,28 @@ fn connection_pool_decoherence() {
         assert!(stats.total_connections == max_connections);
     }
 }
+
+#[test]
+fn connection_pool_no_backends() {
+   
+    let resolver = FakeResolver::new(vec![]);
+
+    let pool_opts = ConnectionPoolOptions {
+        max_connections: Some(1),
+        claim_timeout: Some(1000),
+        log: None,
+        rebalancer_action_delay: None,
+        decoherence_interval: Some(10000),
+        connection_check_interval: Some(1),
+    };
+
+    let _pool = ConnectionPool::new(pool_opts, resolver, DummyConnection::new);
+
+    // sleep so that rebalance can run
+    let sleep_time = time::Duration::from_millis(5000);
+    thread::sleep(sleep_time);
+
+    // we should only get here if the pool rebalance panics due 
+    // to divide-by-zero
+    assert!(true);
+}


### PR DESCRIPTION
It is possible for a rebalance check to be kicked off automatically before there are any backends in  cueball, which can cause a divide-by-zero panic.

Add a check for zero backends in the rebalance code.

Before the fix the test fails:
```
thread 'Timer thread' panicked at 'called `Result::unwrap()` on an `Err` value: "PoisonError { inner: .. }"', src/libcore/result.rs:997:5
thread '<unnamed>' panicked at 'called `Result::unwrap()` on an `Err` value: "PoisonError { inner: .. }"', src/libcore/result.rs:997:5
test connection_pool_no_backends ... FAILED
test connection_pool_decoherence ... ok

failures:

---- connection_pool_no_backends stdout ----
thread 'connection_pool_no_backends' panicked at 'called `Result::unwrap()` on an `Err` value: "PoisonError { inner: .. }"', src/libcore/result.rs:997:5


failures:
    connection_pool_no_backends

test result: FAILED. 4 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out
```
After the fix is in place:
```
test connection_pool_no_backends ... ok
test connection_pool_decoherence ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

   Doc-tests cueball

running 2 tests
test src/lib.rs -  (line 136) ... ignored
test src/lib.rs -  (line 40) ... ignored

test result: ok. 0 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out
```