### PR TITLE
Logic inversion in remove_backend function

### DIFF
--- a/cueball/CHANGES.md
+++ b/cueball/CHANGES.md
@@ -1,5 +1,9 @@
 # rust-cueball changelog
 
+## not yet released
+
+- [joyent/rust-cueball#43] Logic inversion in remove_backend function
+
 ## 0.3.3
 
 - [joyent/rust-cueball#24] Rebalance with no backends can cause a crash

--- a/cueball/src/connection_pool.rs
+++ b/cueball/src/connection_pool.rs
@@ -775,8 +775,8 @@ where
 {
     let mut connection_data = protected_data.connection_data_lock();
 
-    if !connection_data.backends.contains_key(&msg.0) {
-        debug!(log, "Added backend with key {}", &msg.0);
+    if connection_data.backends.contains_key(&msg.0) {
+        debug!(log, "Removing backend with key {}", &msg.0);
         connection_data.backends.remove(&msg.0);
         Some(BackendAction::BackendRemoved)
     } else {


### PR DESCRIPTION
The [`remove_backend`](https://github.com/joyent/rust-cueball/blob/c221c97e5b96db534e84cc24f4af469ab06c5d42/cueball/src/connection_pool.rs#L778-L785) function in the `connection_pool` module can never work correctly due to a logic inversion error.