### PR TITLE
Bump dns-resolver patch version for MANTA-5146.

### DIFF
--- a/resolvers/dns-resolver/Cargo.toml
+++ b/resolvers/dns-resolver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cueball-dns-resolver"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Jon Anderson <jon.anderson@joyent.com>"]
 description = """
 This is a rust implementation of Joyent's node-cueball DNS resolver.


### PR DESCRIPTION
Bump the dns-resolver patch version.