### PR TITLE
MANTA-5259 bump rust-cueball version numbers and publish crates

### DIFF
--- a/connections/postgres-connection/Cargo.toml
+++ b/connections/postgres-connection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cueball-postgres-connection"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Kelly McLaughlin <kelly.mclaughlin@joyent.com>"]
 description = """
 This is an implementation of the cueball Connection trait for postgres::Client from the rust-postgres crate.
@@ -12,7 +12,7 @@ license = "MPL-2.0"
 edition = "2018"
 
 [dependencies]
-cueball = { path = '../../cueball', version = '0.3.0' }
+cueball = { path = '../../cueball', version = '0.3.5' }
 native-tls = "0.2.3"
 postgres = "0.17.3"
 postgres-protocol = "= 0.5.1"

--- a/connections/tcp-stream-connection/Cargo.toml
+++ b/connections/tcp-stream-connection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cueball-tcp-stream-connection"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Kelly McLaughlin <kelly.mclaughlin@joyent.com>"]
 description = """
 This is an implementation of the cueball Connection trait for TcpStream from the rust standard library.
@@ -12,4 +12,4 @@ license = "MPL-2.0"
 edition = "2018"
 
 [dependencies]
-cueball = { path = '../../cueball', version = '0.3.0' }
+cueball = { path = '../../cueball', version = '0.3.5' }

--- a/cueball/Cargo.toml
+++ b/cueball/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cueball"
-version = "0.3.4"
+version = "0.3.5"
 authors = [
         "Kelly McLaughlin <kelly.mclaughlin@joyent.com>",
         "Jon Anderson <jon.anderson@joyent.com>",

--- a/resolvers/dns-resolver/Cargo.toml
+++ b/resolvers/dns-resolver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cueball-dns-resolver"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Jon Anderson <jon.anderson@joyent.com>"]
 description = """
 This is a rust implementation of Joyent's node-cueball DNS resolver.
@@ -14,7 +14,7 @@ edition = "2018"
 [dependencies]
 base64 = "0.10.1"
 chrono = "0.4"
-cueball = { path = "../../cueball" }
+cueball = { path = '../../cueball', version = '0.3.5' }
 custom_derive = "0.1.7"
 derive_more = "0.14.0"
 futures = "0.1"

--- a/resolvers/manatee-primary-resolver/Cargo.toml
+++ b/resolvers/manatee-primary-resolver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cueball-manatee-primary-resolver"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Kelly McLaughlin <kelly.mclaughlin@joyent.com>", "Isaac Davis <isaac.davis@joyent.com>"]
 description = """
 An implementation of the cueball Resolver trait that is specific to the Joyent manatee project. It queries a zookeeper
@@ -15,7 +15,7 @@ edition = "2018"
 [dependencies]
 backoff = "0.1.6"
 clap = "2.32"
-cueball = { path = "../../cueball", version = "0.3.0" }
+cueball = { path = "../../cueball", version = "0.3.5" }
 itertools = "0.8.0"
 failure = "0.1.5"
 futures = "0.1.28"

--- a/resolvers/static-resolver/Cargo.toml
+++ b/resolvers/static-resolver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cueball-static-resolver"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Kelly McLaughlin <kelly.mclaughlin@joyent.com>"]
 description = """
 This is an implementation of the cueball Resolver trait that provides a static list of backends for use by the connection pool.
@@ -12,7 +12,7 @@ license = "MPL-2.0"
 edition = "2018"
 
 [dependencies]
-cueball = { path = '../../cueball', version = '0.3.0' }
+cueball = { path = '../../cueball', version = '0.3.5' }
 
 [dev-dependencies]
 cueball-tcp-stream-connection = { path = '../../connections/tcp-stream-connection', version = '0.3.0' }

--- a/tools/manatee-echo-resolver/Cargo.toml
+++ b/tools/manatee-echo-resolver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "manatee-echo-resolver"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Isaac Davis <isaac.davis@joyent.com>"]
 description = """
 Runs a manatee primary resolver instance and prints its logging, as well as
@@ -14,6 +14,6 @@ edition = "2018"
 
 [dependencies]
 clap = "2.32"
-cueball = { path = "../../cueball", version = "0.3.0" }
-cueball-manatee-primary-resolver = { path = "../../resolvers/manatee-primary-resolver" }
+cueball = { path = "../../cueball", version = "0.3.5" }
+cueball-manatee-primary-resolver = { path = "../../resolvers/manatee-primary-resolver", version = "0.5.1" }
 slog = { version = "2.4.1", features = [ "max_level_trace" ] }


### PR DESCRIPTION
Most of this is to get MANTA-5256 available for buckets-mdapi

All 7 members of this repo have been touched and will need to be published