### PR TITLE
Update tokio-zookeeper dependency in the Manatee resolver.

### DIFF
--- a/resolvers/manatee-primary-resolver/Cargo.toml
+++ b/resolvers/manatee-primary-resolver/Cargo.toml
@@ -26,7 +26,7 @@ serde_json = "1.0.40"
 slog = { version = "2.4.1", features = [ "max_level_trace" ] }
 slog-bunyan = "2.2.0"
 tokio = "0.1.22"
-tokio-zookeeper = { git = 'https://github.com/joyent/tokio-zookeeper', tag = "v0.1.3" }
+tokio-zookeeper = { version = "0.1.3", package = "joyent-tokio-zookeeper" }
 url = "2.1.0"
 uuid = { version = "0.8", features = ["v4"] }
 


### PR DESCRIPTION
Change the tokio-zookeeper crate to the Joyent fork for now, using version 0.1.3.