### PR TITLE
MANTA-5282 rust-cueball correctly handle postgres ssl modes allow, prefer, and require

### DIFF
--- a/connections/postgres-connection/Cargo.toml
+++ b/connections/postgres-connection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cueball-postgres-connection"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Kelly McLaughlin <kelly.mclaughlin@joyent.com>"]
 description = """
 This is an implementation of the cueball Connection trait for postgres::Client from the rust-postgres crate.


### PR DESCRIPTION
for postgres SSL modes allow, prefer, and require, a root cert given is *optional*.  If it is given, it is used to validate the validity of the server certificates.  If it is omitted, it is ignored and *any* certificate is accepted.  This PR aligns native-tls / our implementation with how postgres works.  If a cert is given with any of these 3 options, it will be used to validate the server authenticity.  If it is omitted, all SSL certs will be considered valid.

This was tested via MANTA-5283 (https://jenkins.joyent.us/job/joyent-org/job/manta-buckets-mdapi/job/MANTA-5283/1/console) with mdapi on my own test machine.  I modified the config.toml file for mdapi to set ssl from "disable" to "require" and verified that it connected to postgres using SSL with a self signed cert.

the postgres-connection portion of this crate will need to be published when this is merged.